### PR TITLE
perf: send local description sooner, trickle ICE

### DIFF
--- a/src/lib/calls.ts
+++ b/src/lib/calls.ts
@@ -2,13 +2,11 @@
 const rtcConfiguration = {
   iceServers: [
     { urls: "stun:stun.l.google.com:19302" },
-    /*
     {
       urls: "turn:c20.testrun.org",
       username: "ohV8aec1",
       credential: "zo3theiY",
-      },
-      */
+    },
   ],
   iceTransportPolicy: "all",
   //iceTransportPolicy: "relay",


### PR DESCRIPTION
This should ensure that there are no 5+ second delays
when establising the connection,
due to ICE gathering taking long to complete.

I have checked that this works,
also with `iceTransportPolicy: "relay"`.

I am, however, unsure about how good of an idea the whole concept
of ICE trickling over the data channel is.
So I created a StackOverflow question:
https://stackoverflow.com/questions/79750433/is-ice-trickling-signaling-over-turn-data-channel-a-good-idea.
