### PR TITLE
fix: don't mirror the other party's video

### DIFF
--- a/src/components/FullscreenVideo.tsx
+++ b/src/components/FullscreenVideo.tsx
@@ -11,14 +11,7 @@ interface Props {
 export default function FullscreenVideo({ videoRef }: Props) {
   return (
     <div style={containerStyle}>
-      <video
-        style={{ transform: "scaleX(-1)" }}
-        width="100%"
-        height="100%"
-        autoPlay
-        playsInline
-        ref={videoRef}
-      />
+      <video width="100%" height="100%" autoPlay playsInline ref={videoRef} />
     </div>
   );
 }


### PR DESCRIPTION
Mirroring makes sense for self video,
but the other party should appear as they appear in real life.
