### PR TITLE
fix: make sure to call `pc.close()` on `endCall`

### DIFF
--- a/src/lib/calls.ts
+++ b/src/lib/calls.ts
@@ -154,6 +154,7 @@ export class CallsManager {
   }
 
   async endCall(): Promise<void> {
+    this.peerConnection.close();
     window.calls.endCall();
   }
 


### PR DESCRIPTION
This should end the call faster,
without waiting for the `window.calls.endCall()` to do its thing.
