### PR TITLE
fix: display placeholder on avatar fetch error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,11 +87,15 @@ export default function App() {
           height: "100%",
         }}
       >
-        {window.calls.getAvatar ? (
-          <AvatarImage url={window.calls.getAvatar()} />
-        ) : (
+        <div style={{ position: "relative" }}>
           <AvatarPlaceholder />
-        )}
+          {window.calls.getAvatar && (
+            <AvatarImage
+              url={window.calls.getAvatar()}
+              style={{ position: "absolute", inset: 0 }}
+            />
+          )}
+        </div>
       </div>
       <div
         style={{

--- a/src/components/AvatarImage.tsx
+++ b/src/components/AvatarImage.tsx
@@ -5,8 +5,6 @@ interface Props {
 
 export default function AvatarImage({ url, ...props }: Props) {
   props.style = {
-    width: "8em",
-    height: "8em",
     borderRadius: "50%",
     backgroundImage: `url(${url})`,
     backgroundSize: "cover",


### PR DESCRIPTION
If the image returned from `getAvatar()` URL fails to load,
still display the placeholder.

This will help on Delta Chat desktop where we don't have a method
to generate "initial letter avatar" images.
We only do those with CSS.
