### PR TITLE
feat: option to disable video completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ In order to start the app in audio-only mode initially,
 provide `noOutgoingVideoInitially` in the query (search) string
 of the initial URL, e.g. `/index.html?noOutgoingVideoInitially#startCall`.
 
+In order to completely disable incoming and outgoing video,
+provide `disableVideoCompletely` in the query string of the URL.
+See <https://github.com/deltachat/calls-webapp/issues/31>.
+
 ## Contributing
 
 ### Installing Dependencies


### PR DESCRIPTION
Partially addresses
https://github.com/deltachat/calls-webapp/issues/31.

This is for Delta Touch (Ubuntu Touch),
where incoming video seems to cause crashes.

Note that if one party didn't `disableVideoCompletely`,
they will still be able to send outgoing video,
but the other party (who has `disableVideoCompletely`)
will not see it.

TODO:
- [x] Merge the base branch into main, such that only one commit remains.
  https://github.com/deltachat/calls-webapp/pull/44
