### PR TITLE
feat: utilize `MediaSession` API: PiP, etc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,39 @@ export default function App() {
     manager.endCall();
   }, [manager]);
 
+  // MediaSession API stuff, from this sample:
+  // https://googlechrome.github.io/samples/media-session/video-conferencing.html.
+  // Not critical, but can be nice if the platform (browser and the OS)
+  // support it.
+  useEffect(() => {
+    (navigator.mediaSession as any).setCameraActive(isOutVideoEnabled);
+  }, [isOutVideoEnabled]);
+  useEffect(() => {
+    (navigator.mediaSession as any).setMicrophoneActive(isOutAudioEnabled);
+  }, [isOutAudioEnabled]);
+  useEffect(() => {
+    try {
+      navigator.mediaSession.setActionHandler("togglemicrophone" as any, () => {
+        setIsOutAudioEnabled((v) => !v);
+      });
+      navigator.mediaSession.setActionHandler("togglecamera" as any, () => {
+        setIsOutVideoEnabled((v) => !v);
+      });
+      navigator.mediaSession.setActionHandler(
+        "enterpictureinpicture" as any,
+        () => {
+          incVidRef.current?.requestPictureInPicture();
+        },
+      );
+      navigator.mediaSession.setActionHandler("hangup" as any, () => {
+        endCall();
+        document.exitPictureInPicture();
+      });
+    } catch (error) {
+      console.warn("MediaSession features are not supported", error);
+    }
+  }, [endCall, incVidRef]);
+
   let status: string;
   switch (state) {
     case "promptingUserToAcceptCall":


### PR DESCRIPTION
On Android this should let us utilize Picture-in-Picture
when minimizing the app to the background.
This also enables mic and camera toggles
on the said Picture-in-Picture window.

On Windows on Delta Chat Desktop this does not appear
to have much of an effect currently.
This will not `requestPictureInPicture()` automatically
(but you can try it manually to see what it looks like).
Additionally, the `MediaSession` seems to be limited on Electron
in general:
https://github.com/electron/electron/issues/25539.

But this has a potential for exploration if we add an explicit
"Picture-in-Picture" button.
Such a native Chromium Picture-in-Picture window
looks basically equivalent to what we have implemented manually
in this app.

Anyways, how well this works depends on the platform
that the app is running in, so let's do our part.

I suggest to test this on Android and iOS.
Or not test and just merge it straight away, hoping that it is useful, or will become useful one day.
