### PR TITLE
override default video poster

### DIFF
--- a/src/components/FullscreenVideo.tsx
+++ b/src/components/FullscreenVideo.tsx
@@ -11,7 +11,14 @@ interface Props {
 export default function FullscreenVideo({ videoRef }: Props) {
   return (
     <div style={containerStyle}>
-      <video width="100%" height="100%" autoPlay playsInline ref={videoRef} />
+      <video
+        poster="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+        width="100%"
+        height="100%"
+        autoPlay
+        playsInline
+        ref={videoRef}
+      />
     </div>
   );
 }

--- a/src/components/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail.tsx
@@ -19,6 +19,7 @@ export default function VideoThumbnail({ videoRef }: Props) {
   return (
     <div style={containerStyle}>
       <video
+        poster="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
         style={{
           borderRadius: "5px",
           objectFit: "cover",


### PR DESCRIPTION
for now just make it transparent (black video), in the future we could consider improve it ex. a undefined loading/spinning progress bar o some other custom poster

close #47 