### PR TITLE
fix: don't reassign `incVid.srcObject`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,9 @@ export default function App() {
       }
 
       const vid = incVidRef.current!;
-      vid.srcObject = incStream;
+      if (vid.srcObject !== incStream) {
+        vid.srcObject = incStream;
+      }
 
       // On Delta Touch (Ubuntu Touch, Chromium 87)
       // the caller's audio doesn't seem to auto-play


### PR DESCRIPTION
Apparently this does cause some side effects,
probably negative ones.
The examples in the
[WebRTC browser spec](https://w3c.github.io/webrtc-pc/)
do roughly the same:

> ```javascript
> // don't set srcObject again if it is already set.
> if (remoteView.srcObject) return;
> remoteView.srcObject = streams[0];
> ```
