### PR TITLE
inject version number in built app

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
     "strictNullChecks": true,
     "noImplicitAny": true
   },
-  "include": ["src"]
+  "include": ["src", "vite-plugins", "vite.config.ts"]
 }

--- a/vite-plugins/inject-version.ts
+++ b/vite-plugins/inject-version.ts
@@ -1,0 +1,43 @@
+import { Plugin } from "vite";
+import { execSync } from "child_process";
+
+function getVersion(): string {
+  try {
+    return execSync("git describe --tags", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+export default function injectVersion(): Plugin {
+  const version = getVersion();
+
+  return {
+    name: "vite:version-inject",
+    apply: "build",
+    enforce: "post",
+    generateBundle(_, bundle) {
+      for (const fileName of Object.keys(bundle)) {
+        if (fileName === "index.html" || fileName.endsWith("/index.html")) {
+          const chunk: any = bundle[fileName];
+          if (chunk.type === "asset" && typeof chunk.source === "string") {
+            const comment = `<!-- version: ${version} -->`;
+            if (chunk.source.includes("<head>")) {
+              const script = `<script>console.log("version: ${version}");</script>`;
+              chunk.source = chunk.source.replace(
+                "<head>",
+                `${comment}<head>${script}`,
+              );
+            } else {
+              chunk.source = comment + chunk.source;
+            }
+          }
+        }
+      }
+    },
+  };
+}

--- a/vite-plugins/inject-version.ts
+++ b/vite-plugins/inject-version.ts
@@ -25,15 +25,11 @@ export default function injectVersion(): Plugin {
         if (fileName === "index.html" || fileName.endsWith("/index.html")) {
           const chunk: any = bundle[fileName];
           if (chunk.type === "asset" && typeof chunk.source === "string") {
-            const comment = `<!-- version: ${version} -->`;
             if (chunk.source.includes("<head>")) {
               const script = `<script>console.log("version: ${version}");</script>`;
-              chunk.source = chunk.source.replace(
-                "<head>",
-                `${comment}<head>${script}`,
-              );
+              chunk.source = chunk.source.replace("<head>", `<head>${script}`);
             } else {
-              chunk.source = comment + chunk.source;
+              chunk.source = `<!-- version: ${version} -->` + chunk.source;
             }
           }
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
+// @ts-ignore
 import { eruda, mockWebxdc } from "@webxdc/vite-plugins";
 import preact from "@preact/preset-vite";
 import Icons from "unplugin-icons/vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
+import injectVersion from "./vite-plugins/inject-version";
 
 import { defineConfig } from "vite";
 import path from "path";
@@ -9,6 +11,7 @@ import path from "path";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    injectVersion(),
     preact(),
     viteSingleFile(),
     Icons({ compiler: "jsx", jsx: "react" }),


### PR DESCRIPTION
ex. `v0.7.0` or `v0.7.0-1-g687c503` for commit not tagged yet

the version is printed with `console.log()` so it can be checked in the devtools' console (ex. with Eruda in debug builds or DC desktop's devtools