### PR TITLE
feat: try to show avatar if remote has no video

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,58 @@ export default function App() {
     (window as any).__callsManager = manager;
   }, [manager]);
 
+  const [incStreamVideoTracks, setIncStreamVideoTracks] = useState<
+    undefined | MediaStreamTrack[]
+  >(undefined);
+  useEffect(() => {
+    if (incStream == null) {
+      setIncStreamHasVideo(undefined);
+      return;
+    }
+
+    const checkTracks = () => {
+      setIncStreamVideoTracks(incStream.getVideoTracks());
+    };
+    checkTracks();
+
+    incStream.addEventListener("addtrack", checkTracks);
+    incStream.addEventListener("removetrack", checkTracks);
+    return () => {
+      incStream.removeEventListener("addtrack", checkTracks);
+      incStream.removeEventListener("removetrack", checkTracks);
+    };
+  }, [incStream]);
+  const [incStreamHasVideo, setIncStreamHasVideo] = useState<
+    undefined | boolean
+  >(undefined);
+  useEffect(() => {
+    if (incStreamVideoTracks == undefined) {
+      setIncStreamHasVideo(undefined);
+      return;
+    }
+
+    const checkMuted = () => {
+      setIncStreamHasVideo(incStreamVideoTracks.some((t) => !t.muted));
+
+      console.log(
+        "incStream.videoTracks() muted states:",
+        incStreamVideoTracks.map((t) => t.muted),
+      );
+    };
+    checkMuted();
+
+    incStreamVideoTracks.forEach((t) => {
+      t.addEventListener("mute", checkMuted);
+      t.addEventListener("unmute", checkMuted);
+    });
+    return () => {
+      incStreamVideoTracks.forEach((t) => {
+        t.removeEventListener("mute", checkMuted);
+        t.removeEventListener("unmute", checkMuted);
+      });
+    };
+  }, [incStreamVideoTracks]);
+
   useEffect(() => {
     if (outStream == undefined) {
       return;
@@ -182,11 +234,17 @@ export default function App() {
     }
   }, [state]);
 
-  const inCall = state === "in-call";
+  const showIncVideo = state === "in-call" && incStreamHasVideo;
   const containerStyle = {
-    display: inCall ? "block" : "none",
+    display: state === "in-call" ? "block" : "none",
+    position: "absolute",
+    top: 0,
+    width: "100%",
+    // Otherwise there is vertical scroll. IDK if this is right,
+    // but does the job.
+    overflow: "hidden",
     height: "100%",
-  };
+  } as const;
 
   const toggleAudioLabel = isOutAudioEnabled
     ? "Mute microphone"
@@ -203,7 +261,7 @@ export default function App() {
   return (
     <div style={{ height: "100vh", overflow: "hidden" }}>
       <div style={containerStyle}>
-        <FullscreenVideo mediaStream={incStream} />
+        <FullscreenVideo mediaStream={incStream} hide={!showIncVideo} />
         <VideoThumbnail videoRef={outVidRef} />
       </div>
 
@@ -221,7 +279,7 @@ export default function App() {
       </div>
       <div
         style={{
-          display: inCall ? "none" : "flex",
+          display: showIncVideo ? "none" : "flex",
           alignItems: "center",
           textAlign: "center",
           justifyContent: "center",

--- a/src/components/FullscreenVideo.tsx
+++ b/src/components/FullscreenVideo.tsx
@@ -8,9 +8,10 @@ const containerStyle = {
 
 interface Props {
   mediaStream: MediaStream | null;
+  hide: boolean;
 }
 
-export default function FullscreenVideo({ mediaStream }: Props) {
+export default function FullscreenVideo({ mediaStream, hide }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
   /**
    * This element will play the same source as the video element.
@@ -100,7 +101,7 @@ export default function FullscreenVideo({ mediaStream }: Props) {
   }, [mediaStream, videoRef, audioRef]);
 
   return (
-    <div style={containerStyle}>
+    <div style={{ ...containerStyle, display: hide ? "none" : undefined }}>
       <video
         muted={fallBackToAudioEl}
         poster="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="


### PR DESCRIPTION
TODO:
- [x] Address the added TODO (see code)

Partially addresses
https://github.com/deltachat/calls-webapp/issues/62.

This only works if the remote disabled video via
`replaceTrack(null)`, which is only utilized by
https://github.com/deltachat/deltachat-ios/pull/2909
as of writing, or if the remote has no camera at all (only mic).
