### PR TITLE
improvement: show camera button for non-audio-only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,7 +277,10 @@ export default function App() {
   const toggleAudioLabel = isOutAudioEnabled
     ? "Mute microphone"
     : "Unmute microphone";
-  const toggleVideoLabel = isOutVideoEnabled ? "Stop camera" : "Start camera";
+  const toggleVideoLabel =
+    isOutVideoEnabled && outStreamHasVideoTrack
+      ? "Stop camera"
+      : "Start camera";
 
   const buttonsStyle = {
     color: "white",
@@ -352,14 +355,21 @@ export default function App() {
             <MaterialSymbolsMicOff />
           )}
         </Button>
-        {outStreamHasVideoTrack && (
+        {/* If `enableVideoInitially`, which is the case for calls
+        that have been started as video (and not only-audio) calls,
+        then we want to make it clear to the user
+        that they can't enable the camera. */}
+        {(outStreamHasVideoTrack || enableVideoInitially) && (
           <Button
             aria-label={toggleVideoLabel}
             title={toggleVideoLabel}
+            disabled={!outStreamHasVideoTrack}
             onClick={() => setIsOutVideoEnabled((v) => !v)}
             style={buttonsStyle}
           >
-            {isOutVideoEnabled ? (
+            {/* TODO `isOutVideoEnabled` should never be `true`
+            if `outStreamHasVideoTrack === false`? */}
+            {isOutVideoEnabled && outStreamHasVideoTrack ? (
               <MaterialSymbolsVideocam />
             ) : (
               <MaterialSymbolsVideocamOff />


### PR DESCRIPTION
This should help the user recognize
that they cannot enable the camera,
and not that the button just disappeared for no reason.

Partially addresses https://github.com/deltachat/calls-webapp/issues/62.

<img width="400" height="504" alt="image" src="https://github.com/user-attachments/assets/05556c9b-82b1-452e-b7b8-0e8357fb284c" />

I have tested this on a device with no camera. I have not tested this with `enableVideoInitially === false`.