### PR TITLE
fix: use connectionState to transition to in-call

### DIFF
--- a/src/lib/calls.ts
+++ b/src/lib/calls.ts
@@ -171,17 +171,27 @@ export class CallsManager {
     this.peerConnection.ontrack = (e: RTCTrackEvent) => {
       const stream = e.streams[0];
       onIncomingStream(stream);
-      this.state = "in-call";
-      this.onStateChanged(this.state);
     };
+
+    this.peerConnection.addEventListener("connectionstatechange", () => {
+      console.log(
+        "onconnectionstatechange",
+        this.peerConnection.connectionState,
+      );
+
+      if (this.peerConnection.connectionState === "connecting") {
+        this.state = "in-call";
+        this.onStateChanged(this.state);
+      }
+    });
 
     // Print the selected candidate pair(s), for debugging,
     // and invoke `onRelayUsageChange`.
-    const connectionstatechangeListener = () => {
+    const connectionstatechangeListener2 = () => {
       if (this.peerConnection.connectionState === "connected") {
         this.peerConnection.removeEventListener(
           "connectionstatechange",
-          connectionstatechangeListener,
+          connectionstatechangeListener2,
         );
 
         // `setTimeout` for things to settle.
@@ -237,7 +247,7 @@ export class CallsManager {
     };
     this.peerConnection.addEventListener(
       "connectionstatechange",
-      connectionstatechangeListener,
+      connectionstatechangeListener2,
     );
 
     const acceptCall = async (payload: string) => {


### PR DESCRIPTION
This ensured that we tell the user that the call has started
even if the other party fails to (or maliciously decides not to)
send their media stream.
